### PR TITLE
refactor: break out utils

### DIFF
--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -9,37 +9,19 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const astUtils = require('./utils/ast-utils'),
-  naturalCompare = require('natural-compare')
+const reportUtils = require('./utils/report-utils'),
+  sharedUtils = require('../shared/utils'),
+  sortKeysUtils = require('./utils/sort-keys-utils')
 
 // ------------------------------------------------------------------------------
 // Helpers
 // ------------------------------------------------------------------------------
 
-/** @typedef {import('../shared/types').ExclusifyUnion<import('estree').Node>} ASTNode */
-/** @typedef {import('../shared/types').ExclusifyUnion<ASTNode['key']>} ASTPropKeyNode */
-/**
- * @typedef Override
- * @property {string} [message] Message
- * @property {string[]} order Property Order
- * @property {string[]} [properties] Name of parent property to apply this override to. If omitted, the object's keys
- *                                   must be a total subset of the properties defined in order
- */
-/**
- * @typedef Options
- * @property {boolean} [caseSensitive] Use case sensitive sorting
- * @property {boolean} [natural] Use natural sorting
- * @property {number} [minKeys] Minimum Keys
- * @property {boolean} [allowLineSeparatedGroups] Allow Line Separated Groups
- * @property {boolean} [ignoreSingleLine] Ignore Single Line
- * @property {'first' | 'last' | 'ignore'} [allCaps] All Caps option
- * @property {'first' | 'last' | 'ignore'} [shorthand] shorthand option
- * @property {Override[]} [overrides] Overrides options
- */
-/**
- * @template [T=string]
- * @typedef {(a: T, b: T) => boolean | null} IsValidOrder
- */
+/** @typedef {import('../shared/types').ASTNode} ASTNode */
+/** @typedef {import('../shared/types').ASTPropertyKeyNode} ASTPropertyKeyNode */
+/** @typedef {import('../shared/types').SortOrderOverride} SortOrderOverride */
+/** @typedef {import('../shared/types').SortRuleOptions} SortRuleOptions */
+
 /**
  * @typedef Stack
  * @property {Stack | null} upper
@@ -50,103 +32,9 @@ const astUtils = require('./utils/ast-utils'),
  * @property {boolean} prevNameSkipped
  * @property {number} numKeys
  * @property {string} parentName
- * @property {Override} override
- * @property {IsValidOrder} isValidOrderOverride
+ * @property {SortOrderOverride} override
+ * @property {sortKeysUtils.IsValidOrder} isValidOrderOverride
  */
-
-/**
- * Combinatorial combination fn
- * @template T
- * @param {T[]} arr items
- * @param {number} minLength minimum length
- * @returns {T[][]} combinations
- */
-function combination(arr, minLength) {
-  /** @type {T[][]} */
-  const initialValue = []
-
-  return arr
-    .reduce((out, item) => [...out, [item], ...out.map(c => [...c, item])], initialValue)
-    .filter(c => c.length >= minLength)
-}
-
-/**
- * Gets the property name of the given `Property` node.
- *
- * - If the property's key is an `Identifier` node, this returns the key's name
- *   whether it's a computed property or not.
- * - If the property has a static name, this returns the static name.
- * - Otherwise, this returns null.
- * @param {ASTNode} node The `Property` node to get.
- * @returns {string|null} The property name or null.
- * @private
- */
-function getPropertyName(node) {
-  const staticName = astUtils.getStaticPropertyName(node)
-
-  if (staticName !== null) {
-    return staticName
-  }
-
-  /** @type {ASTPropKeyNode | undefined} */
-  const key = node.key
-
-  return (key && key.name) || null
-}
-
-/**
- * test blank lines
- * @param {import('eslint').Rule.RuleContext} context context
- * @param {import('eslint').Rule.Node} node node
- * @param {import('eslint').Rule.Node} prevNode prevNode
- * @returns {boolean} if there is a blank line between the prevNode and current node
- */
-function hasBlankLineBetweenNodes(context, node, prevNode) {
-  const sourceCode = context.getSourceCode()
-
-  // Get tokens between current node and previous node
-  const tokens = prevNode && sourceCode.getTokensBetween(prevNode, node, { includeComments: true })
-
-  if (!tokens) {
-    return false
-  }
-  let previousToken
-
-  // check blank line between tokens
-  for (let i = 0; i < tokens.length; i++) {
-    const token = tokens[i]
-
-    if (previousToken && token.loc.start.line - previousToken.loc.end.line > 1) {
-      return true
-    }
-    previousToken = token
-  }
-
-  // check blank line between the current node and the last token
-  if (node.loc.start.line - tokens[tokens.length - 1].loc.end.line > 1) {
-    return true
-  }
-
-  // check blank line between the first token and the previous node
-  if (tokens[0].loc.start.line - prevNode.loc.end.line > 1) {
-    return true
-  }
-  return false
-}
-
-/**
- * Function to check that 2 names are proper all caps order
- * @param {string} a first value
- * @param {string} b second value
- * @returns {boolean | null} if the values are in valid order; null if both are all caps or both not all caps
- * @private
- */
-function isValidAllCapsTest(a, b) {
-  const aIsAllCaps = a === a.toUpperCase()
-  const bIsAllCaps = b === b.toUpperCase()
-
-  return aIsAllCaps === bIsAllCaps ? null : aIsAllCaps && !bIsAllCaps
-}
 
 /**
  * Function to check that 2 nodes are proper shorthand order
@@ -157,147 +45,6 @@ function isValidAllCapsTest(a, b) {
  */
 function isValidShorthandTest(a, b) {
   return !a.shorthand === !b.shorthand ? null : Boolean(a.shorthand && !b.shorthand)
-}
-
-/**
- * reverse order function
- * @template T
- * @param {IsValidOrder<T>} isValidOrder order function
- * @returns {IsValidOrder<T>} reversed order function
- */
-const reverseOrder = isValidOrder => (a, b) => isValidOrder(b, a) // eslint-disable-line func-style
-
-const returnNull = () => null // eslint-disable-line func-style
-
-/**
- * transform test
- * @template T
- * @param {'ignore' | 'first' | 'last'} option Option value
- * @param {IsValidOrder<T>} isValidOrder base test
- * @returns {IsValidOrder<T>} new test
- */
-function firstLastTest(option, isValidOrder) {
-  switch (option) {
-    case 'first':
-      return isValidOrder
-    case 'last':
-      return reverseOrder(isValidOrder)
-    default:
-      return returnNull
-  }
-}
-
-/**
- * Functions which check that the given 2 names are in specific order.
- *
- * Postfix `I` is meant insensitive.
- * Postfix `N` is meant natural.
- * @type {Record<`${'asc'|'desc'}${''|'I'}${''|'N'}`, IsValidOrder>}
- * @private
- */
-// @ts-ignore
-const isValidOrders = {
-  asc(a, b) {
-    return a <= b
-  },
-  ascI(a, b) {
-    return a.toLowerCase() <= b.toLowerCase()
-  },
-  ascN(a, b) {
-    return naturalCompare(a, b) <= 0
-  },
-  ascIN(a, b) {
-    return naturalCompare(a.toLowerCase(), b.toLowerCase()) <= 0
-  },
-}
-
-Object.keys(isValidOrders).forEach(asc => {
-  const desc = `desc${asc.slice(3)}`
-
-  isValidOrders[desc] = Object.defineProperty(reverseOrder(isValidOrders[asc]), 'name', { value: desc })
-})
-
-/**
- * Customize
- * @param {string[]} order custom order of properties
- * @returns {IsValidOrder} comparator
- */
-function validCustomOrderComparator(order) {
-  return (a, b) => {
-    const aIndex = order.indexOf(a)
-    const bIndex = order.indexOf(b)
-
-    if (aIndex >= 0) {
-      if (bIndex >= 0) {
-        return aIndex <= bIndex
-      }
-      return true
-    }
-    return bIndex < 0 && null
-  }
-}
-
-/**
- * create fixer
- * @param {import('eslint').Rule.RuleContext} context context
- * @param {import('eslint').Rule.Node} node node
- * @param {import('eslint').Rule.Node} prevNode prevNode
- * @returns {import('eslint').Rule.ReportFixer} fixer
- */
-function createFixer(context, node, prevNode) {
-  return function fix(fixer) {
-    const fixes = []
-    const sourceCode = context.getSourceCode()
-
-    /**
-     * Move Property
-     * @param {import('eslint').Rule.Node} fromNode From Node
-     * @param {import('eslint').Rule.Node} toNode To Node
-     * @returns {void}
-     */
-    function moveProperty(fromNode, toNode) {
-      const prevText = sourceCode.getText(fromNode)
-      const thisComments = sourceCode.getCommentsBefore(fromNode)
-
-      for (const thisComment of thisComments) {
-        fixes.push(fixer.insertTextBefore(toNode, `${sourceCode.getText(thisComment)}\n`))
-        fixes.push(fixer.remove(thisComment))
-      }
-      fixes.push(fixer.replaceText(toNode, prevText))
-    }
-
-    moveProperty(node, prevNode)
-    moveProperty(prevNode, node)
-    return fixes
-  }
-}
-
-/**
- * create report
- * @param {import('eslint').Rule.RuleContext} context context
- * @param {import('estree').Property} node node
- * @param {import('estree').Property} prevNode previous node
- * @param {boolean} fixable create fixer
- * @param {string} messageId message id
- * @param {{thisName: string, prevName: string, overrideMessage?: string, [key: string]: any}} data message data
- * @returns {void}
- */
-function createReport(context, node, prevNode, fixable, messageId, data) {
-  const reportMessage = data.overrideMessage
-    ? { message: `${data.overrideMessage} '{{thisName}}' should be before '{{prevName}}'.` }
-    : { messageId }
-  /** @type {import('eslint').Rule.ReportDescriptor} */
-  const report = {
-    node,
-    loc: node.key.loc,
-    ...reportMessage,
-    data,
-  }
-
-  if (fixable) {
-    report.fix = createFixer(context, node, prevNode)
-  }
-  context.report(report)
 }
 
 // ------------------------------------------------------------------------------
@@ -396,7 +143,7 @@ module.exports = {
     // Parse options.
     /** @type {'asc' | 'desc'} */
     const order = context.options[0] || 'asc'
-    /** @type {Options | undefined} */
+    /** @type {SortRuleOptions | undefined} */
     const options = context.options[1]
     const insensitive = options && options.caseSensitive === false
     const natural = options && options.natural
@@ -405,13 +152,13 @@ module.exports = {
     const ignoreSingleLine = (options && options.ignoreSingleLine) || false
     const allCaps = (options && options.allCaps) || 'ignore'
     const shorthand = (options && options.shorthand) || 'ignore'
-    /** @type {Override[]} */
+    /** @type {SortOrderOverride[]} */
     const overrides = (options && options.overrides) || []
-    /** @type {Map<string | undefined, Override>} */
+    /** @type {Map<string | undefined, SortOrderOverride>} */
     const propOverrides = new Map(
       overrides.flatMap(item => (item.properties ? item.properties.map(property => [property, item]) : [])),
     )
-    /** @type {Map<string, Override>} */
+    /** @type {Map<string, SortOrderOverride>} */
     const otherOverrides = new Map()
 
     overrides.forEach(override => {
@@ -421,7 +168,7 @@ module.exports = {
 
       const sorted = override.order.concat().sort()
 
-      combination(sorted, minKeys).forEach(combo => {
+      sharedUtils.combination(sorted, minKeys).forEach(combo => {
         const key = combo.join()
         const existing = otherOverrides.get(key)
 
@@ -430,9 +177,9 @@ module.exports = {
         }
       })
     })
-    const isValidOrderAlpha = isValidOrders[`${order}${insensitive ? 'I' : ''}${natural ? 'N' : ''}`]
-    const isValidOrderAllCaps = firstLastTest(allCaps, isValidAllCapsTest)
-    const isValidOrderShorthand = firstLastTest(shorthand, isValidShorthandTest)
+    const isValidOrderAlpha = sortKeysUtils.isValidOrders[`${order}${insensitive ? 'I' : ''}${natural ? 'N' : ''}`]
+    const isValidOrderAllCaps = sortKeysUtils.firstLastTest(allCaps, sortKeysUtils.isValidAllCapsTest)
+    const isValidOrderShorthand = sortKeysUtils.firstLastTest(shorthand, isValidShorthandTest)
 
     /**
      * The stack to save the previous property's name for each object literals.
@@ -463,7 +210,7 @@ module.exports = {
         let override
 
         if (parent.type === 'Property' && !parent.computed) {
-          /** @type {ASTPropKeyNode} */
+          /** @type {ASTPropertyKeyNode} */
           const parentKey = parent.key
 
           parentName = typeof parentKey.value === 'string' ? parentKey.value : parentKey.name
@@ -471,7 +218,7 @@ module.exports = {
         }
         if (!override && otherOverrides.size > 0) {
           const key = node.properties
-            .map(getPropertyName)
+            .map(sortKeysUtils.getPropertyName)
             .filter(name => name !== null)
             .sort()
             .join()
@@ -489,7 +236,7 @@ module.exports = {
           numKeys: node.properties.length,
           parentName,
           override,
-          isValidOrderOverride: override && validCustomOrderComparator(override.order),
+          isValidOrderOverride: override && sortKeysUtils.validCustomOrderComparator(override.order),
         }
       },
 
@@ -509,9 +256,9 @@ module.exports = {
         const prevNameSkipped = stack.prevNameSkipped
         const fixable = !prevNameSkipped
         const numKeys = stack.numKeys
-        const thisName = getPropertyName(node)
+        const thisName = sortKeysUtils.getPropertyName(node)
         const isBlankLineBetweenNodes =
-          stack.prevBlankLine || (allowLineSeparatedGroups && hasBlankLineBetweenNodes(context, node, prevNode))
+          stack.prevBlankLine || (allowLineSeparatedGroups && sortKeysUtils.hasBlankLineBetweenNodes(context, node, prevNode))
 
         stack.prevNode = node
         stack.prevNameSkipped = thisName === null
@@ -532,7 +279,7 @@ module.exports = {
         const isValidOverride = stack.isValidOrderOverride && stack.isValidOrderOverride(prevName, thisName)
 
         if (isValidOverride === false) {
-          createReport(context, node, prevNode, fixable, 'sortKeysOverride', {
+          reportUtils.createReport(context, node, prevNode, fixable, 'sortKeysOverride', {
             thisName,
             prevName,
             parentName: stack.parentName || '',
@@ -548,7 +295,7 @@ module.exports = {
         const isValidAllCaps = isValidOrderAllCaps(prevName, thisName)
 
         if (isValidAllCaps === false) {
-          createReport(context, node, prevNode, fixable, 'sortKeysAllCaps', {
+          reportUtils.createReport(context, node, prevNode, fixable, 'sortKeysAllCaps', {
             thisName,
             prevName,
             allCaps,
@@ -559,7 +306,7 @@ module.exports = {
         const isValidShorthand = isValidOrderShorthand(prevNode, node)
 
         if (isValidShorthand === false) {
-          createReport(context, node, prevNode, fixable, 'sortKeysShorthand', {
+          reportUtils.createReport(context, node, prevNode, fixable, 'sortKeysShorthand', {
             thisName,
             prevName,
             shorthand,
@@ -572,7 +319,7 @@ module.exports = {
         }
 
         if (!isValidOrderAlpha(prevName, thisName)) {
-          createReport(context, node, prevNode, fixable, 'sortKeys', {
+          reportUtils.createReport(context, node, prevNode, fixable, 'sortKeys', {
             thisName,
             prevName,
             order,

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -9,7 +9,7 @@
 // Typedefs
 //------------------------------------------------------------------------------
 
-/** @typedef {import('../../shared/types').ExclusifyUnion<import('estree').Node>} ASTNode */
+/** @typedef {import('../../shared/types').ASTNode>} ASTNode */
 /** @typedef {import('estree').Comment & { type: 'Block'}} Block */
 /** @typedef {import('estree').Comment & { type: 'Line'}} Line */
 /** @typedef {import('eslint').AST.SourceLocation} SourceLocation */

--- a/lib/rules/utils/report-utils.js
+++ b/lib/rules/utils/report-utils.js
@@ -1,0 +1,70 @@
+'use strict'
+
+/**
+ * create fixer
+ * @param {import('eslint').Rule.RuleContext} context context
+ * @param {import('eslint').Rule.Node} node node
+ * @param {import('eslint').Rule.Node} prevNode prevNode
+ * @returns {import('eslint').Rule.ReportFixer} fixer
+ */
+function createFixer(context, node, prevNode) {
+  return function fix(fixer) {
+    /** @type {import('eslint').Rule.Fix[]} */
+    const fixes = []
+    const sourceCode = context.getSourceCode()
+
+    /**
+     * Move Property
+     * @param {import('eslint').Rule.Node} fromNode From Node
+     * @param {import('eslint').Rule.Node} toNode To Node
+     * @returns {void}
+     */
+    function moveProperty(fromNode, toNode) {
+      const prevText = sourceCode.getText(fromNode)
+      const thisComments = sourceCode.getCommentsBefore(fromNode)
+
+      for (const thisComment of thisComments) {
+        fixes.push(fixer.insertTextBefore(toNode, `${sourceCode.getText(thisComment)}\n`))
+        fixes.push(fixer.remove(thisComment))
+      }
+      fixes.push(fixer.replaceText(toNode, prevText))
+    }
+
+    moveProperty(node, prevNode)
+    moveProperty(prevNode, node)
+    return fixes
+  }
+}
+
+/**
+ * create report
+ * @param {import('eslint').Rule.RuleContext} context context
+ * @param {import('estree').Property} node node
+ * @param {import('estree').Property} prevNode previous node
+ * @param {boolean} fixable create fixer
+ * @param {string} messageId message id
+ * @param {{thisName: string, prevName: string, overrideMessage?: string, [key: string]: any}} data message data
+ * @returns {void}
+ */
+function createReport(context, node, prevNode, fixable, messageId, data) {
+  const reportMessage = data.overrideMessage
+    ? { message: `${data.overrideMessage} '{{thisName}}' should be before '{{prevName}}'.` }
+    : { messageId }
+  /** @type {import('eslint').Rule.ReportDescriptor} */
+  const report = {
+    node,
+    loc: node.key.loc,
+    ...reportMessage,
+    data,
+  }
+
+  if (fixable) {
+    report.fix = createFixer(context, node, prevNode)
+  }
+  context.report(report)
+}
+
+module.exports = {
+  createFixer,
+  createReport,
+}

--- a/lib/rules/utils/sort-keys-utils.js
+++ b/lib/rules/utils/sort-keys-utils.js
@@ -1,0 +1,174 @@
+'use strict'
+
+const astUtils = require('./ast-utils'),
+  naturalCompare = require('natural-compare')
+
+/**
+ * @template [T=string]
+ * @typedef {(a: T, b: T) => boolean | null} IsValidOrder
+ */
+
+/**
+ * Gets the property name of the given `Property` node.
+ *
+ * - If the property's key is an `Identifier` node, this returns the key's name
+ *   whether it's a computed property or not.
+ * - If the property has a static name, this returns the static name.
+ * - Otherwise, this returns null.
+ * @param {ASTNode} node The `Property` node to get.
+ * @returns {string|null} The property name or null.
+ * @private
+ */
+function getPropertyName(node) {
+  const staticName = astUtils.getStaticPropertyName(node)
+
+  if (staticName !== null) {
+    return staticName
+  }
+
+  /** @type {ASTPropertyKeyNode | undefined} */
+  const key = node.key
+
+  return (key && key.name) || null
+}
+
+/**
+ * test blank lines
+ * @param {import('eslint').Rule.RuleContext} context context
+ * @param {import('eslint').Rule.Node} node node
+ * @param {import('eslint').Rule.Node} prevNode prevNode
+ * @returns {boolean} if there is a blank line between the prevNode and current node
+ */
+function hasBlankLineBetweenNodes(context, node, prevNode) {
+  const sourceCode = context.getSourceCode()
+
+  // Get tokens between current node and previous node
+  const tokens = prevNode && sourceCode.getTokensBetween(prevNode, node, { includeComments: true })
+
+  if (!tokens) {
+    return false
+  }
+  let previousToken
+
+  // check blank line between tokens
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i]
+
+    if (previousToken && token.loc.start.line - previousToken.loc.end.line > 1) {
+      return true
+    }
+    previousToken = token
+  }
+
+  // check blank line between the current node and the last token
+  if (node.loc.start.line - tokens[tokens.length - 1].loc.end.line > 1) {
+    return true
+  }
+
+  // check blank line between the first token and the previous node
+  if (tokens[0].loc.start.line - prevNode.loc.end.line > 1) {
+    return true
+  }
+  return false
+}
+
+/**
+ * Function to check that 2 names are proper all caps order
+ * @param {string} a first value
+ * @param {string} b second value
+ * @returns {boolean | null} if the values are in valid order; null if both are all caps or both not all caps
+ * @private
+ */
+function isValidAllCapsTest(a, b) {
+  const aIsAllCaps = a === a.toUpperCase()
+  const bIsAllCaps = b === b.toUpperCase()
+
+  return aIsAllCaps === bIsAllCaps ? null : aIsAllCaps && !bIsAllCaps
+}
+
+/**
+ * reverse order function
+ * @template T
+ * @param {IsValidOrder<T>} isValidOrder order function
+ * @returns {IsValidOrder<T>} reversed order function
+ */
+const reverseOrder = isValidOrder => (a, b) => isValidOrder(b, a) // eslint-disable-line func-style
+
+const returnNull = () => null // eslint-disable-line func-style
+
+/**
+ * transform test
+ * @template T
+ * @param {'ignore' | 'first' | 'last'} option Option value
+ * @param {IsValidOrder<T>} isValidOrder base test
+ * @returns {IsValidOrder<T>} new test
+ */
+function firstLastTest(option, isValidOrder) {
+  switch (option) {
+    case 'first':
+      return isValidOrder
+    case 'last':
+      return reverseOrder(isValidOrder)
+    default:
+      return returnNull
+  }
+}
+
+/**
+ * Functions which check that the given 2 names are in specific order.
+ *
+ * Postfix `I` is meant insensitive.
+ * Postfix `N` is meant natural.
+ * @type {Record<`${'asc'|'desc'}${''|'I'}${''|'N'}`, IsValidOrder>}
+ * @private
+ */
+// @ts-ignore
+const isValidOrders = {
+  asc(a, b) {
+    return a <= b
+  },
+  ascI(a, b) {
+    return a.toLowerCase() <= b.toLowerCase()
+  },
+  ascN(a, b) {
+    return naturalCompare(a, b) <= 0
+  },
+  ascIN(a, b) {
+    return naturalCompare(a.toLowerCase(), b.toLowerCase()) <= 0
+  },
+}
+
+Object.keys(isValidOrders).forEach(asc => {
+  const desc = `desc${asc.slice(3)}`
+
+  isValidOrders[desc] = Object.defineProperty(reverseOrder(isValidOrders[asc]), 'name', { value: desc })
+})
+
+/**
+ * Customize
+ * @param {string[]} order custom order of properties
+ * @returns {IsValidOrder} comparator
+ */
+function validCustomOrderComparator(order) {
+  return (a, b) => {
+    const aIndex = order.indexOf(a)
+    const bIndex = order.indexOf(b)
+
+    if (aIndex >= 0) {
+      if (bIndex >= 0) {
+        return aIndex <= bIndex
+      }
+      return true
+    }
+    return bIndex < 0 && null
+  }
+}
+
+module.exports = {
+  getPropertyName,
+  hasBlankLineBetweenNodes,
+  isValidAllCapsTest,
+  firstLastTest,
+  isValidOrders,
+  validCustomOrderComparator,
+}

--- a/lib/shared/types.d.ts
+++ b/lib/shared/types.d.ts
@@ -1,7 +1,9 @@
+import { Node } from 'estree'
+
 type AllKeys<T> = T extends unknown ? keyof T : never;
 type Id<T> = T extends infer U ? { [K in keyof U]: U[K] } : never;
 type _ExclusifyUnion<T, K extends PropertyKey> =
-    T extends unknown ? Id<T & Partial<Record<Exclude<K, keyof T>, never>>> : never;
+    T extends unknown ? T & Id<Partial<Record<Exclude<K, keyof T>, never>>> : never;
 export type ExclusifyUnion<T> = _ExclusifyUnion<T, AllKeys<T>>;
 
 declare module 'eslint' {
@@ -20,4 +22,32 @@ declare module 'estree' {
   interface BaseNode {
     loc: SourceLocation;
   }
+}
+
+export type ASTNode = ExclusifyUnion<Node>;
+type ASTNodesWithKey = Extract<Node, { key: any }>;
+export type ASTPropertyKeyNode = ExclusifyUnion<ASTNodesWithKey['key']>;
+
+export interface SortOrderOverride {
+  message?: string;
+  order: string[];
+  /**
+   * Name of parent property to apply this override to. If omitted, the
+   * object's keys must be a total subset of the properties defined in order
+   */
+  properties?: string[];
+}
+
+interface SortRuleOptions {
+  caseSensitive?: boolean;
+  natural?: boolean;
+  minKeys?: number;
+  allowLineSeparatedGroups?: boolean;
+  ignoreSingleLine?: boolean;
+  allCaps?: 'first' | 'last' | 'ignore';
+  overrides?: SortOrderOverride[];
+}
+
+export interface SortKeysOptions extends SortRuleOptions {
+  shorthand?: 'first' | 'last' | 'ignore';
 }

--- a/lib/shared/utils.js
+++ b/lib/shared/utils.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Combinatorial combination fn
+ * @template T
+ * @param {T[]} arr items
+ * @param {number} minLength minimum length
+ * @returns {T[][]} combinations
+ */
+function combination(arr, minLength) {
+  /** @type {T[][]} */
+  const initialValue = []
+
+  return arr
+    .reduce((out, item) => [...out, [item], ...out.map(c => [...c, item])], initialValue)
+    .filter(c => c.length >= minLength)
+}
+
+module.exports = {
+  combination,
+}


### PR DESCRIPTION
Fixes #6

Import the member-ordering rule from hhttps://github.com/typescript-eslint/typescript-eslint/blob/v6.4.1/packages/eslint-plugin/src/rules/member-ordering.ts, and implement a fixer.

This will probably involve adopting the option format of the member-ordering rule, and adding shared config.